### PR TITLE
switch node build image to lts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest as node_setup
+FROM node:lts as node_setup
 WORKDIR /root/
 COPY ./ui/package.json ./
 COPY ./ui/yarn.lock ./


### PR DESCRIPTION
`node:latest` has a weird dependency break with parcel and terser, switching to `node:lts` fixed it.