### PR TITLE
Added a created at field for sessions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       - "8080:8080"
     depends_on:
       - db
+    volumes:
+      - "/etc/timezone:/etc/timezone:ro"
+      - "/etc/localtime:/etc/localtime:ro"
     build:
       dockerfile: Dockerfile
       context: .

--- a/session.go
+++ b/session.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -16,10 +17,12 @@ type Session struct {
 	Description   string `json:"description"`
 	Retrospective string `json:"retrospective"`
 	Completed     bool   `json:"completed"`
+	CreatedAt     string `json:"created_at"`
 }
 
 func (session *Session) BeforeCreate(scope *gorm.DB) error {
 	session.ID = uuid.New().String()
+	session.CreatedAt = time.Now().Format("15:04:05")
 	return nil
 }
 


### PR DESCRIPTION
**Added the created-at-field to sessions.**
There was an issue with the time.now() function when ran in docker not having the same time as the host machine. So, made changes to the docker file to reflect the host machine time. In terms of format for the time I'm not sure how it will work with the tutor UI in terms of being able to sort it, never sorted anything by the time so we will find out as we go. The current time format is "hh:mm:ss". 

Didn't include the date in the format because a session lasting more than a day is crazy. 